### PR TITLE
Style fix: Removed crosshair pointer in PD controller

### DIFF
--- a/tutorials/pdControl/style.css
+++ b/tutorials/pdControl/style.css
@@ -3,7 +3,8 @@
 svg {
     background-color: #bbbbbb;
     box-shadow: 0 1px 4px -2px;
-    cursor: crosshair;
+    /* In some browsers, the "crosshair" is the same as the background color, and thus becomes invisible */
+    /* cursor: crosshair;  */
     margin-left: auto;
     margin-right: auto;
     display: block;


### PR DESCRIPTION
On some systems, the crosshair pointer is the exact color of the
background, so the crosshair pointer is invisible.

The crosshairs are a cute addition, but the regular mouse pointer is plenty functional for this application. Other fixes could be: Change the color of the panel background, more advanced pointer selection


Steps to repro:
Windows 10 Home, OS build 18362.778:
  Firefox 75.0
  Chrome 80

Go to
http://www.matthewpeterkelly.com/tutorials/pdControl/index.html
and move the mouse onto the panel with the `target` and `chaser` circle



The crosshair looks fine on:
  Ubuntu 16.04 (Firefox)
  ChromeOS (Chrome)
  